### PR TITLE
Add Azure cleanup script for deleting datasets/blobs via Cosmos metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 backend/__pycache__/
 backend/datara/__pycache__/
 backend/datara/services/__pycache__/
+backend/utils/__pycache__/
 backend/*.pyc
 backend/venv/
 backend/.env

--- a/backend/app.py
+++ b/backend/app.py
@@ -5,6 +5,9 @@ Main Flask application for robotics training and deployment.
 Handles Azure Blob Storage integration and dataset management.
 """
 
+import os
+import subprocess
+import sys
 from datetime import datetime, timezone
 
 from flask import Flask, jsonify, Response, stream_with_context, request
@@ -144,6 +147,34 @@ def register_routes(app: Flask) -> None:
         except Exception as e:
             logger.error(f"Error generating ego: {e}", exc_info=True)
             return {"error": f"An error occurred: {str(e)}"}, 500
+
+    @app.route("/api/delete_dataset", methods=["POST"])
+    def delete_dataset():
+        """Delete a dataset path and its subdirectories via delete_from_azure.py script."""
+        try:
+            data = request.get_json() or {}
+            path = data.get("path") or (request.form.get("path") if request.form else None)
+            if not path or not str(path).strip():
+                return jsonify({"error": "Missing or empty 'path'"}), 400
+            path = str(path).strip().rstrip("/")
+            backend_dir = os.path.dirname(os.path.abspath(__file__))
+            utils_dir = os.path.join(backend_dir, "utils")
+            script_path = os.path.join(utils_dir, "delete_from_azure.py")
+            result = subprocess.run(
+                [sys.executable, script_path, "--dataset_prefix", path],
+                capture_output=True,
+                text=True,
+                cwd=backend_dir,
+            )
+            if result.returncode != 0:
+                err = (result.stderr or result.stdout or "Unknown error").strip()
+                logger.warning(f"delete_from_azure failed: {err}")
+                return jsonify({"error": err or "Delete script failed"}), 500
+            logger.info(f"Dataset deleted via script: {path}")
+            return jsonify({"message": "Dataset and subdirectories deleted"})
+        except Exception as e:
+            logger.error(f"Error deleting dataset: {e}", exc_info=True)
+            return jsonify({"error": str(e)}), 500
 
     @app.route("/api/stats", methods=["GET"])
     def get_stats():

--- a/backend/datara/services/processing_service.py
+++ b/backend/datara/services/processing_service.py
@@ -8,6 +8,7 @@ import subprocess
 from datetime import datetime
 from typing import Dict, Any
 
+import cv2
 import gdown
 
 from datara.logging import logger
@@ -15,6 +16,8 @@ from datara.logging import logger
 # Get the backend directory path and utils path
 BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 UTILS_DIR = os.path.join(BACKEND_DIR, "utils")
+# All upload scripts receive input_dir under this base (backend/utils/dataset_list)
+DATASET_LIST_DIR = os.path.join(UTILS_DIR, "dataset_list")
 
 
 class ProcessingService:
@@ -77,7 +80,7 @@ class ProcessingService:
         else:
             dataset_basename = f"dataset_{ts}"
 
-        local_process_dir = os.path.join("dataset_list", dataset_basename)
+        local_process_dir = os.path.join(DATASET_LIST_DIR, dataset_basename)
 
         try:
             if os.path.exists(local_process_dir):
@@ -89,7 +92,7 @@ class ProcessingService:
             else:
                 self._process_video_file(gdrive_link, local_process_dir, dataset_basename, ts)
 
-            # Upload to Azure
+            # Upload to Azure (input_dir is backend/utils/dataset_list/<dataset_basename>)
             self._upload_to_azure(
                 local_process_dir,
                 output_name or dataset_basename,
@@ -194,14 +197,24 @@ class ProcessingService:
             if not downloaded_path:
                 raise ValueError("Download failed or link invalid")
 
-            # Generate frames from video
+            # Use video's native FPS so we don't downsample (e.g. 60 fps video stays 60 fps)
+            cap = cv2.VideoCapture(downloaded_path)
+            try:
+                video_fps = cap.get(cv2.CAP_PROP_FPS)
+                target_fps = float(video_fps) if video_fps and video_fps > 0 else 30.0
+                logger.info(f"Video FPS: {target_fps:.2f}")
+            finally:
+                cap.release()
+
+            # Generate frames from video (--output_dir = backend/utils/dataset_list/<name>)
             logger.info(f"Generating frames from video: {dataset_basename}")
             cmd = [
                 sys.executable,
                 os.path.join(UTILS_DIR, "generate_orig_frames.py"),
                 "--video_path", downloaded_path,
                 "--output_name", dataset_basename,
-                "--target_fps", "30"
+                "--target_fps", str(target_fps),
+                "--output_dir", local_process_dir,
             ]
 
             subprocess.check_call(cmd)
@@ -290,21 +303,29 @@ class ProcessingService:
                 return {"message": f"Ego generation failed: {str(e)}"}
 
             if local_image_path:
-                # Upload ego images
+                # Place ego image under backend/utils/dataset_list/<path>/egos for upload
+                output_name_ego = "/".join(path_components[1:4])
+                ego_input_dir = os.path.join(DATASET_LIST_DIR, output_name_ego)
+                ego_egos_dir = os.path.join(ego_input_dir, "egos")
+                os.makedirs(ego_egos_dir, exist_ok=True)
+                ego_dest = os.path.join(ego_egos_dir, os.path.basename(local_image_path))
+                shutil.copy2(local_image_path, ego_dest)
+
                 cmd = [
                     sys.executable,
                     os.path.join(UTILS_DIR, "upload_frames_to_azure.py"),
                     "--container_name", container_name,
-                    "--output_name", "/".join(path_components[1:4]),
-                    "--input_dir", os.path.dirname(os.path.dirname(local_image_path)),
+                    "--output_name", output_name_ego,
+                    "--input_dir", ego_input_dir,
                     "--view", "egos",
                     "--date", date_val or "",
                     "--tags", json.dumps(misc_tags)
                 ]
-
                 subprocess.check_call(cmd)
 
                 # Cleanup
+                if os.path.exists(ego_input_dir):
+                    shutil.rmtree(ego_input_dir)
                 ego_dir = f"ego_images/{container_name}"
                 if os.path.exists(ego_dir):
                     shutil.rmtree(ego_dir)

--- a/backend/utils/azure_client.py
+++ b/backend/utils/azure_client.py
@@ -1,0 +1,133 @@
+"""
+Shared Azure client helpers for Blob Storage and Cosmos DB.
+
+Used by delete_from_azure, upload_frames_to_azure, and upload_glb_to_azure
+to connect to Azure resources and perform uploads/deletes consistently.
+
+Environment variables (with fallbacks):
+- Blob: BLOB_CONNECTION_STRING or AZURE_STORAGE_CONNECTION_STRING
+- Blob container: AZURE_BLOB_CONTAINER (default: roboteyeview)
+- Cosmos: COSMOS_DB_KEY or AZURE_COSMOS_KEY
+- Cosmos endpoint: COSMOS_ENDPOINT or AZURE_COSMOS_ENDPOINT (or default below)
+"""
+
+import os
+from typing import Any, Optional, Tuple
+
+from dotenv import load_dotenv
+from azure.storage.blob import BlobServiceClient
+from azure.core.exceptions import ResourceExistsError
+from azure.cosmos import CosmosClient
+
+# Defaults when not overridden by env or arguments
+COSMOS_ENDPOINT_DEFAULT = "https://daas-blob-annotations.documents.azure.com:443/"
+COSMOS_DATABASE = "BlobAnnotations"
+COSMOS_CONTAINER = "roboteyeview"
+BLOB_CONTAINER_DEFAULT = "roboteyeview"
+
+
+def get_blob_connection_string(connection_string: Optional[str] = None) -> str:
+    """Resolve blob storage connection string from arg or env."""
+    load_dotenv()
+    out = (
+        connection_string
+        or os.getenv("BLOB_CONNECTION_STRING")
+        or os.getenv("AZURE_STORAGE_CONNECTION_STRING")
+    )
+    if not out:
+        raise ValueError(
+            "Missing blob connection string. Set BLOB_CONNECTION_STRING or "
+            "AZURE_STORAGE_CONNECTION_STRING, or pass --connection_string."
+        )
+    return out
+
+
+def get_blob_container(
+    connection_string: Optional[str] = None,
+    container_name: Optional[str] = None,
+) -> Any:
+    """
+    Return an Azure Blob Storage container client.
+    connection_string and container_name default from environment if not provided.
+    """
+    load_dotenv()
+    conn_str = get_blob_connection_string(connection_string)
+    name = container_name or os.getenv("AZURE_BLOB_CONTAINER", BLOB_CONTAINER_DEFAULT)
+    blob_service = BlobServiceClient.from_connection_string(conn_str)
+    return blob_service.get_container_client(name)
+
+
+def ensure_blob_container_exists(container_client: Any) -> None:
+    """
+    Create the blob container if it does not exist.
+    Raises RuntimeError if the container is currently being deleted.
+    """
+    try:
+        if not container_client.exists():
+            print(f"Container '{container_client.container_name}' does not exist. Creating it...")
+            container_client.create_container()
+        else:
+            print(f"Using existing container '{container_client.container_name}'")
+    except ResourceExistsError as e:
+        if "being deleted" in str(e):
+            raise RuntimeError(
+                "Container is currently being deleted by Azure. "
+                "Wait 1–2 minutes and retry."
+            )
+        raise
+
+
+def get_cosmos_key() -> str:
+    """Resolve Cosmos DB key from environment."""
+    load_dotenv()
+    key = os.getenv("COSMOS_DB_KEY") or os.getenv("AZURE_COSMOS_KEY")
+    if not key:
+        raise ValueError(
+            "Missing Cosmos key. Set COSMOS_DB_KEY or AZURE_COSMOS_KEY."
+        )
+    return key
+
+
+def get_cosmos_container(
+    cosmos_key: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    database: Optional[str] = None,
+    container: Optional[str] = None,
+) -> Any:
+    """
+    Return the Cosmos DB container client for annotations (roboteyeview).
+    All arguments default from environment or module constants.
+    """
+    load_dotenv()
+    key = cosmos_key or get_cosmos_key()
+    ep = (
+        endpoint
+        or os.getenv("COSMOS_ENDPOINT")
+        or os.getenv("AZURE_COSMOS_ENDPOINT")
+        or COSMOS_ENDPOINT_DEFAULT
+    )
+    db = database or COSMOS_DATABASE
+    cont = container or COSMOS_CONTAINER
+    client = CosmosClient(ep, credential=key)
+    return client.get_database_client(db).get_container_client(cont)
+
+
+def get_azure_clients(
+    connection_string: Optional[str] = None,
+    blob_container_name: Optional[str] = None,
+    cosmos_key: Optional[str] = None,
+    cosmos_endpoint: Optional[str] = None,
+) -> Tuple[Any, Any]:
+    """
+    Return (blob_container_client, cosmos_container_client) for scripts that need both.
+    Uses env for any argument not provided.
+    """
+    blob_container = get_blob_container(
+        connection_string=connection_string,
+        container_name=blob_container_name,
+    )
+    cosmos_container = get_cosmos_container(
+        cosmos_key=cosmos_key,
+        endpoint=cosmos_endpoint,
+    )
+    return blob_container, cosmos_container

--- a/backend/utils/delete_from_azure.py
+++ b/backend/utils/delete_from_azure.py
@@ -2,39 +2,51 @@
 Delete dataset assets from Azure Blob Storage and Cosmos DB.
 
 Examples:
-    python backend/utils/delete_from_azure.py --dataset bmw_front --dry_run
-    python backend/utils/delete_from_azure.py --dataset bmw_front --view orig --dry_run
-    python backend/utils/delete_from_azure.py --tag grille
-    python backend/utils/delete_from_azure.py --dataset bmw_front --tag grille --view egos
+    python backend/utils/delete_from_azure.py \
+        --dataset bmw_front \
+        --dry_run
+    python backend/utils/delete_from_azure.py \
+        --dataset bmw_front \
+        --view orig \
+        --dry_run
+    python backend/utils/delete_from_azure.py \
+        --tag grille
+    python backend/utils/delete_from_azure.py \
+        --dataset bmw_front \
+        --tag grille \
+        --view egos
+    python backend/utils/delete_from_azure.py \
+        --dataset_prefix automotive/bmw \
+        --dry_run
 
 Safety:
-- Requires at least one filter: --dataset, --tag, or --view
+- Requires at least one filter: --dataset, --dataset_prefix, --tag, or --view
+- --dataset_prefix: delete path and all subdirectories (datasetName = prefix OR STARTSWITH(datasetName, prefix + "/"))
 - Queries Cosmos DB first and only deletes matching blobs/documents
 - Supports dry-run mode
 """
 
 import argparse
 import os
+import sys
 from typing import Any, Dict, List, Optional, Tuple
 
-from dotenv import load_dotenv
-from azure.storage.blob import BlobServiceClient
 from azure.core.exceptions import ResourceNotFoundError
-from azure.cosmos import CosmosClient
 from azure.cosmos.exceptions import CosmosResourceNotFoundError
 
-
-COSMOS_ENDPOINT_DEFAULT = "https://daas-blob-annotations.documents.azure.com:443/"
-COSMOS_DATABASE = "BlobAnnotations"
-COSMOS_CONTAINER = "roboteyeview"
-BLOB_CONTAINER_DEFAULT = "roboteyeview"
+# Allow running as python backend/utils/delete_from_azure.py
+_BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+from utils import azure_client
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Delete matching data from Azure Blob Storage and Cosmos DB"
     )
-    parser.add_argument("--dataset", type=str, default="", help="Match c.datasetName")
+    parser.add_argument("--dataset", type=str, default="", help="Match c.datasetName (exact)")
+    parser.add_argument("--dataset_prefix", type=str, default="", help="Match path and subpaths: datasetName = prefix OR STARTSWITH(datasetName, prefix + '/')")
     parser.add_argument("--tag", type=str, default="", help="Match a value inside c.miscTags")
     parser.add_argument(
         "--view",
@@ -52,10 +64,10 @@ def parse_args() -> argparse.Namespace:
 
 
 def require_filter(args: argparse.Namespace) -> None:
-    if not args.dataset and not args.tag and not args.view:
+    if not args.dataset and not getattr(args, "dataset_prefix", "") and not args.tag and not args.view:
         raise ValueError(
             "Refusing to run without filters. Provide at least one of: "
-            "--dataset, --tag, --view"
+            "--dataset, --dataset_prefix, --tag, --view"
         )
 
 
@@ -87,29 +99,7 @@ def build_cosmos_query(dataset: str, tag: str, view: str) -> Tuple[str, List[Dic
 
 
 def build_clients() -> Tuple[Any, Any]:
-    load_dotenv()
-
-    connection_string = os.getenv("BLOB_CONNECTION_STRING") or os.getenv("AZURE_STORAGE_CONNECTION_STRING")
-    if not connection_string:
-        raise ValueError(
-            "Missing blob connection string. Set BLOB_CONNECTION_STRING or AZURE_STORAGE_CONNECTION_STRING."
-        )
-
-    cosmos_endpoint = os.getenv("COSMOS_ENDPOINT") or os.getenv("AZURE_COSMOS_ENDPOINT") or COSMOS_ENDPOINT_DEFAULT
-    cosmos_key = os.getenv("COSMOS_DB_KEY") or os.getenv("AZURE_COSMOS_KEY")
-    if not cosmos_key:
-        raise ValueError("Missing Cosmos key. Set COSMOS_DB_KEY or AZURE_COSMOS_KEY.")
-
-    container_name = os.getenv("AZURE_BLOB_CONTAINER", BLOB_CONTAINER_DEFAULT)
-
-    blob_service_client = BlobServiceClient.from_connection_string(connection_string)
-    blob_container = blob_service_client.get_container_client(container_name)
-
-    cosmos_client = CosmosClient(cosmos_endpoint, credential=cosmos_key)
-    cosmos_database = cosmos_client.get_database_client(COSMOS_DATABASE)
-    cosmos_container = cosmos_database.get_container_client(COSMOS_CONTAINER)
-
-    return blob_container, cosmos_container
+    return azure_client.get_azure_clients()
 
 
 def get_partition_key_field(cosmos_container: Any) -> Optional[str]:
@@ -140,6 +130,23 @@ def query_matching_docs(
     view: str,
 ) -> List[Dict[str, Any]]:
     query, parameters = build_cosmos_query(dataset=dataset, tag=tag, view=view)
+    return list(
+        cosmos_container.query_items(
+            query=query,
+            parameters=parameters,
+            enable_cross_partition_query=True,
+        )
+    )
+
+
+def query_matching_docs_by_prefix(
+    cosmos_container: Any,
+    dataset_prefix: str,
+) -> List[Dict[str, Any]]:
+    """Query Cosmos for docs where datasetName = prefix or datasetName starts with prefix + '/'."""
+    prefix_slash = dataset_prefix.rstrip("/") + "/"
+    query = "SELECT * FROM c WHERE c.datasetName = @prefix OR STARTSWITH(c.datasetName, @prefixSlash)"
+    parameters = [{"name": "@prefix", "value": dataset_prefix.rstrip("/")}, {"name": "@prefixSlash", "value": prefix_slash}]
     return list(
         cosmos_container.query_items(
             query=query,
@@ -226,7 +233,8 @@ def print_final_summary(
     cosmos_summary: Dict[str, int],
 ) -> None:
     print("\n=== Final Summary ===")
-    print(f"dataset filter: {args.dataset or '(none)'}")
+    print(f"dataset filter:       {args.dataset or '(none)'}")
+    print(f"dataset_prefix filter: {getattr(args, 'dataset_prefix', '') or '(none)'}")
     print(f"tag filter:     {args.tag or '(none)'}")
     print(f"view filter:    {args.view or '(none)'}")
     print(f"mode:           {'DRY RUN' if args.dry_run else 'LIVE DELETE'}")
@@ -256,12 +264,16 @@ def main() -> None:
 
     blob_container, cosmos_container = build_clients()
 
-    docs = query_matching_docs(
-        cosmos_container=cosmos_container,
-        dataset=args.dataset,
-        tag=args.tag,
-        view=args.view,
-    )
+    dataset_prefix = getattr(args, "dataset_prefix", "").strip().rstrip("/")
+    if dataset_prefix:
+        docs = query_matching_docs_by_prefix(cosmos_container, dataset_prefix)
+    else:
+        docs = query_matching_docs(
+            cosmos_container=cosmos_container,
+            dataset=args.dataset,
+            tag=args.tag,
+            view=args.view,
+        )
 
     if not docs:
         print("No matching Cosmos documents found. Nothing to delete.")

--- a/backend/utils/generate_orig_frames.py
+++ b/backend/utils/generate_orig_frames.py
@@ -7,11 +7,13 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--video_path", type=str, required=True, help="input mp4 path")
 parser.add_argument("--output_name", type=str, required=True, help="output name for the directory")
 parser.add_argument("--target_fps", type=float, default=1.0, help="how many frames to save per second of video")
+parser.add_argument("--output_dir", type=str, default="", help="optional: directory to write frames (must contain orig/); if not set, uses utils/dataset_list/<output_name>")
 
 args = parser.parse_args()
 video_path = args.video_path
 output_name = args.output_name
 target_fps = args.target_fps
+output_dir_arg = args.output_dir.strip()
 
 if '~' in video_path:
     video_path = video_path.replace("~", os.path.expanduser("~"))
@@ -44,8 +46,11 @@ else:
 pad_width = len(str(expected_output_count))
 # --- FPS LOGIC END ---
 
-directory_name = os.path.dirname(os.path.abspath(__file__))
-output_dir = os.path.join(directory_name, "dataset_list", f"{output_name}")
+if output_dir_arg:
+    output_dir = os.path.abspath(os.path.expanduser(output_dir_arg))
+else:
+    directory_name = os.path.dirname(os.path.abspath(__file__))
+    output_dir = os.path.join(directory_name, "dataset_list", f"{output_name}")
 
 os.makedirs(os.path.join(output_dir, "orig"), exist_ok=True)
 

--- a/backend/utils/upload_frames_to_azure.py
+++ b/backend/utils/upload_frames_to_azure.py
@@ -19,241 +19,135 @@ Notes:
 - Each frame also gets a document in Cosmos DB
 """
 
-import cv2 
-import numpy as np
-import os
+import argparse
 import json
-import argparse 
-from azure.storage.blob import BlobServiceClient, ContentSettings
-from azure.core.exceptions import ResourceExistsError
-from azure.cosmos import CosmosClient
-# import sys
+import os
+import sys
 import uuid
 
-from dotenv import load_dotenv
+import cv2
+import numpy as np
+from azure.storage.blob import ContentSettings
 
-# ----------------------------
-# Cosmos DB Configuration
-# ----------------------------
-COSMOS_ENDPOINT = "https://daas-blob-annotations.documents.azure.com:443/"
-COSMOS_DATABASE = "BlobAnnotations"
-COSMOS_CONTAINER = "roboteyeview"
-COSMOS_KEY = os.getenv("COSMOS_DB_KEY")
+# Allow running as python backend/utils/upload_frames_to_azure.py
+_BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+from utils import azure_client
 
 
 # ----------------------------
 # Argument parsing
 # ----------------------------
-parser = argparse.ArgumentParser(description="Upload dataset images to Azure Blob Storage")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Upload dataset images to Azure Blob Storage")
+    parser.add_argument("--container_name", type=str, required=True, help="Azure container name")
+    parser.add_argument("--output_name", type=str, required=True, help="Azure prefix name (can differ from dataset name)")
+    parser.add_argument("--input_dir", type=str, required=True, help="Base dataset directory (contains orig/ and egos/)")
+    parser.add_argument("--view", type=str, choices=["orig", "egos"], default="orig", help="Dataset view to upload (default: orig)")
+    parser.add_argument("--connection_string", type=str, required=False, help="Azure Blob Storage connection string (optional if BLOB_CONNECTION_STRING env var is set)")
+    parser.add_argument("--date", type=str, default="", help="Upload date (YYYYMMDD)")
+    parser.add_argument("--tags", type=str, default="[]", help="JSON array of tags")
+    return parser.parse_args()
 
-parser.add_argument(
-    "--container_name",
-    type=str,
-    required=True,
-    help="Azure container name"
-)
 
-parser.add_argument(
-    "--output_name",
-    type=str,
-    required=True,
-    help="Azure prefix name (can differ from dataset name)"
-)
-
-parser.add_argument(
-    "--input_dir",
-    type=str,
-    required=True,
-    help="Base dataset directory (contains orig/ and egos/)"
-)
-
-parser.add_argument(
-    "--view",
-    type=str,
-    choices=["orig", "egos"],
-    default="orig",
-    help="Dataset view to upload (default: orig)"
-)
-
-parser.add_argument(
-    "--connection_string",
-    type=str,
-    required=False,
-    help="Azure Blob Storage connection string (optional if BLOB_CONNECTION_STRING env var is set)"
-)
-
-parser.add_argument(
-    "--date",
-    type=str,
-    default="",
-    help="Upload date (YYYYMMDD)"
-)
-
-parser.add_argument(
-    "--tags",
-    type=str,
-    default="[]",
-    help="JSON array of tags"
-)
-
-args = parser.parse_args()
-
-# Parse tags
-try:
-    misc_tags = json.loads(args.tags)
-except Exception:
-    misc_tags = []
-
-# ----------------------------
-# Image clarity helper
-# ----------------------------
 def laplacian_sharpness_score(image_bgr: np.ndarray) -> float:
     gray = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2GRAY)
     lap = cv2.Laplacian(gray, cv2.CV_64F)
     return float(lap.var())
-# ----------------------------
-# Resolve paths
-# ----------------------------
-base_input_dir = os.path.abspath(os.path.expanduser(args.input_dir))
-dataset_name = os.path.basename(os.path.normpath(base_input_dir))
-view = args.view
-
-input_dir = os.path.join(base_input_dir, view)
-
-if not os.path.isdir(input_dir): 
-    raise FileNotFoundError(f"Directory not found: {input_dir}")
 
 
-# ----------------------------
-# Azure Blob client setup
-# ----------------------------
-load_dotenv()
-
-connection_string = args.connection_string or os.getenv("BLOB_CONNECTION_STRING")
-
-if not connection_string:
-    raise ValueError("Azure connection string must be provided via --connection_string or BLOB_CONNECTION_STRING environment variable.")
-
-blob_service_client = BlobServiceClient.from_connection_string(connection_string)
-
-container_client = blob_service_client.get_container_client(args.container_name)
-
-try:
-    if not container_client.exists():
-        print(f"Container '{args.container_name}' does not exist. Creating it...")
-        container_client.create_container()
-    else:
-        print(f"Using existing container '{args.container_name}'")
-except ResourceExistsError as e:
-    if "being deleted" in str(e):
-        raise RuntimeError(
-            "Container is currently being deleted by Azure. "
-            "Wait 1–2 minutes and retry."
-        )
-
-# ----------------------------
-# Cosmos DB client setup
-# ----------------------------
-cosmos_client = CosmosClient(COSMOS_ENDPOINT, credential=COSMOS_KEY)
-cosmos_database = cosmos_client.get_database_client(COSMOS_DATABASE)
-cosmos_container = cosmos_database.get_container_client(COSMOS_CONTAINER)
-
-
-# ----------------------------
-# Check if dataset view already exists
-# ----------------------------
-dataset_prefix = f"{args.output_name}/{view}/"
-
-existing_blobs = list(
-    container_client.list_blobs(name_starts_with=dataset_prefix)
-)
-
-# This was originally used to check if blob exists, and prevent overriding
-# We'll allow it for now
-if existing_blobs:
-    # error_msg = f"⚠️ Dataset view '{dataset_name}/{view}' already exists in container '{args.container_name}'. No files were uploaded."
-    print(f"Dataset view '{dataset_name}/{view}' exists in container '{args.container_name}'.")
-    
-    # 1. Print directly to standard error (so the parent process sees it as an error)
-    # print(error_msg, file=sys.stderr)
-    
-    # 2. Exit with a non-zero code to tell the backend "I failed"
-    # sys.exit(1)
-
-# ----------------------------
-# Upload images
-# ----------------------------
-valid_extensions = (".jpg", ".jpeg", ".png")
-uploaded_count = 0
-
-for filename in os.listdir(input_dir):
-    if not filename.lower().endswith(valid_extensions):
-        continue
-
-    local_path = os.path.join(input_dir, filename)
-    
-    # Clarity check 
-    clarity_threshold = 100.0 
-    img = cv2.imread(local_path)
-    if img is None: 
-        sharpness_score = None
-        is_clear = False
-        height, width = 0, 0
-    else: 
-        sharpness_score = laplacian_sharpness_score(img)
-        is_clear = sharpness_score >= clarity_threshold
-        height, width = img.shape[:2]
-    
-    # Azure blob paths always use forward slashes
-    blob_name = f"{args.output_name}/{view}/{filename}"
-    
-    with open(local_path, "rb") as f:
-        container_client.upload_blob(
-            name=blob_name,
-            data=f,
-            overwrite=True,
-            content_settings=ContentSettings(content_type="image/png")
-        )
-
-    cosmos_view = "exo" if view == "orig" else view
-    # frame_id = f"{args.container_name}_{args.output_name}_{view}_{filename}"
-    frame_id = uuid.uuid4().hex
-    
-    # Extract frameId (last part of filename after underscore, before extension)
-    # e.g., bmwGrille_001.png -> 001
+def main() -> None:
+    args = parse_args()
     try:
-        frame_id_val = os.path.splitext(filename)[0].split('_')[-1]
+        misc_tags = json.loads(args.tags)
     except Exception:
-        frame_id_val = "0"
+        misc_tags = []
 
-    metadata_item = {
-        "id": frame_id,
-        "containerName": args.container_name,
-        "datasetName": args.output_name,
-        "view": cosmos_view,
-        "frameName": filename,
-        "blobPath": blob_name,
-        "date": args.date,
-        "frameId": frame_id_val,
-        "width": width,
-        "height": height,
-        "miscTags": misc_tags,
-        "sharpnessScore": sharpness_score,
-        "clear": is_clear
-    }
-    
-    try:
-        cosmos_container.upsert_item(metadata_item)
-    except Exception as e:
-        print(f"Failed to upload {filename} metadata to Cosmos: {e}")
+    base_input_dir = os.path.abspath(os.path.expanduser(args.input_dir))
+    dataset_name = os.path.basename(os.path.normpath(base_input_dir))
+    view = args.view
+    input_dir = os.path.join(base_input_dir, view)
 
-    uploaded_count += 1
-    print(f"Uploaded ({uploaded_count}): {blob_name}")
+    if not os.path.isdir(input_dir):
+        raise FileNotFoundError(f"Directory not found: {input_dir}")
+
+    container_client = azure_client.get_blob_container(
+        connection_string=args.connection_string,
+        container_name=args.container_name,
+    )
+    azure_client.ensure_blob_container_exists(container_client)
+    cosmos_container = azure_client.get_cosmos_container()
+
+    dataset_prefix = f"{args.output_name}/{view}/"
+    existing_blobs = list(container_client.list_blobs(name_starts_with=dataset_prefix))
+    if existing_blobs:
+        print(f"Dataset view '{dataset_name}/{view}' exists in container '{args.container_name}'.")
+
+    valid_extensions = (".jpg", ".jpeg", ".png")
+    uploaded_count = 0
+
+    for filename in os.listdir(input_dir):
+        if not filename.lower().endswith(valid_extensions):
+            continue
+
+        local_path = os.path.join(input_dir, filename)
+        clarity_threshold = 100.0
+        img = cv2.imread(local_path)
+        if img is None:
+            sharpness_score = None
+            is_clear = False
+            height, width = 0, 0
+        else:
+            sharpness_score = laplacian_sharpness_score(img)
+            is_clear = sharpness_score >= clarity_threshold
+            height, width = img.shape[:2]
+
+        blob_name = f"{args.output_name}/{view}/{filename}"
+        with open(local_path, "rb") as f:
+            container_client.upload_blob(
+                name=blob_name,
+                data=f,
+                overwrite=True,
+                content_settings=ContentSettings(content_type="image/png"),
+            )
+
+        cosmos_view = "exo" if view == "orig" else view
+        frame_id = uuid.uuid4().hex
+        try:
+            frame_id_val = os.path.splitext(filename)[0].split("_")[-1]
+        except Exception:
+            frame_id_val = "0"
+
+        metadata_item = {
+            "id": frame_id,
+            "containerName": args.container_name,
+            "datasetName": args.output_name,
+            "view": cosmos_view,
+            "frameName": filename,
+            "blobPath": blob_name,
+            "date": args.date,
+            "frameId": frame_id_val,
+            "width": width,
+            "height": height,
+            "miscTags": misc_tags,
+            "sharpnessScore": sharpness_score,
+            "clear": is_clear,
+        }
+        try:
+            cosmos_container.upsert_item(metadata_item)
+        except Exception as e:
+            print(f"Failed to upload {filename} metadata to Cosmos: {e}")
+
+        uploaded_count += 1
+        print(f"Uploaded ({uploaded_count}): {blob_name}")
+
+    print(
+        f"✅ Upload complete — {uploaded_count} images uploaded "
+        f"from '{dataset_name}/{view}' to '{args.container_name}'"
+    )
+    print(f"{uploaded_count} documents created in Cosmos DB")
 
 
-print(
-    f"✅ Upload complete — {uploaded_count} images uploaded "
-    f"from '{dataset_name}/{view}' "
-    f"to '{args.container_name}' "
-)
-print(f"{uploaded_count} documents created in Cosmos DB")
+if __name__ == "__main__":
+    main()

--- a/backend/utils/upload_glb_to_azure.py
+++ b/backend/utils/upload_glb_to_azure.py
@@ -17,227 +17,86 @@ Notes:
 - Each frame also gets a document in Cosmos DB
 """
 
-import cv2 
-import numpy as np
+import argparse
 import os
-import json
-import argparse 
-from azure.storage.blob import BlobServiceClient, ContentSettings
-from azure.core.exceptions import ResourceExistsError
-# from azure.cosmos import CosmosClient
+import sys
 
+from azure.storage.blob import ContentSettings
 
-# ----------------------------
-# Cosmos DB Configuration
-# ----------------------------
-# COSMOS_ENDPOINT = "https://daas-blob-annotations.documents.azure.com:443/"
-# COSMOS_DATABASE = "BlobAnnotations"
-# COSMOS_CONTAINER = "roboteyeview"
-# COSMOS_KEY = os.getenv("COSMOS_DB_KEY")
+# Allow running as python backend/utils/upload_glb_to_azure.py
+_BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+from utils import azure_client
 
 
 # ----------------------------
 # Argument parsing
 # ----------------------------
-parser = argparse.ArgumentParser(description="Upload dataset images to Azure Blob Storage")
-
-parser.add_argument(
-    "--container_name",
-    type=str,
-    required=True,
-    help="Azure container name"
-)
-
-parser.add_argument(
-    "--output_name",
-    type=str,
-    required=True,
-    help="Azure prefix name (can differ from dataset name)"
-)
-
-parser.add_argument(
-    "--input_dir",
-    type=str,
-    required=True,
-    help="Base dataset directory (contains 3D_gen/)"
-)
-
-parser.add_argument(
-    "--view",
-    type=str,
-    choices=["3D_gen"],
-    default="3D_gen",
-    help="Dataset view to upload (default: 3D_gen)"
-)
-
-parser.add_argument(
-    "--connection_string",
-    type=str,
-    required=True,
-    help="Azure Blob Storage connection string"
-)
-
-# parser.add_argument(
-#     "--date",
-#     type=str,
-#     default="",
-#     help="Upload date (YYYYMMDD)"
-# )
-
-# parser.add_argument(
-#     "--tags",
-#     type=str,
-#     default="[]",
-#     help="JSON array of tags"
-# )
-
-# parser.add_argument(
-#     "--cosmos_key",
-#     type=str,
-#     help="Azure Cosmos key"
-# )
-
-args = parser.parse_args()
-
-# COSMOS_KEY = args.cosmos_key
-
-# Parse tags
-# try:
-#     misc_tags = json.loads(args.tags)
-# except:
-#     misc_tags = []
-
-# ----------------------------
-# Image clarity helper
-# ----------------------------
-# def laplacian_sharpness_score(image_bgr: np.ndarray) -> float:
-#     gray = cv2.cvtColor(image_bgr, cv2.COLOR_BGR2GRAY)
-#     lap = cv2.Laplacian(gray, cv2.CV_64F)
-#     return float(lap.var())
-# ----------------------------
-# Resolve paths
-# ----------------------------
-base_input_dir = os.path.abspath(os.path.expanduser(args.input_dir))
-dataset_name = os.path.basename(os.path.normpath(base_input_dir))
-view = args.view
-
-input_dir = os.path.join(base_input_dir, view)
-
-if not os.path.isdir(input_dir):
-    raise FileNotFoundError(f"Directory not found: {input_dir}")
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Upload 3D datasets to Azure Blob Storage")
+    parser.add_argument("--container_name", type=str, required=True, help="Azure container name")
+    parser.add_argument("--output_name", type=str, required=True, help="Azure prefix name (can differ from dataset name)")
+    parser.add_argument("--input_dir", type=str, required=True, help="Base dataset directory (contains 3D_gen/)")
+    parser.add_argument("--view", type=str, choices=["3D_gen"], default="3D_gen", help="Dataset view to upload (default: 3D_gen)")
+    parser.add_argument("--connection_string", type=str, default=None, help="Azure Blob Storage connection string (optional if BLOB_CONNECTION_STRING env is set)")
+    return parser.parse_args()
 
 
-# ----------------------------
-# Azure Blob client setup
-# ----------------------------
-blob_service_client = BlobServiceClient.from_connection_string(
-    args.connection_string
-)
+def main() -> None:
+    args = parse_args()
+    base_input_dir = os.path.abspath(os.path.expanduser(args.input_dir))
+    dataset_name = os.path.basename(os.path.normpath(base_input_dir))
+    view = args.view
+    input_dir = os.path.join(base_input_dir, view)
 
-container_client = blob_service_client.get_container_client(args.container_name)
+    if not os.path.isdir(input_dir):
+        raise FileNotFoundError(f"Directory not found: {input_dir}")
 
-try:
-    if not container_client.exists():
-        print(f"Container '{args.container_name}' does not exist. Creating it...")
-        container_client.create_container()
-    else:
-        print(f"Using existing container '{args.container_name}'")
-except ResourceExistsError as e:
-    if "being deleted" in str(e):
-        raise RuntimeError(
-            "Container is currently being deleted by Azure. "
-            "Wait 1–2 minutes and retry."
-        )
-
-# ----------------------------
-# Cosmos DB client setup
-# ----------------------------
-# cosmos_client = CosmosClient(COSMOS_ENDPOINT, credential=COSMOS_KEY)
-# cosmos_database = cosmos_client.get_database_client(COSMOS_DATABASE)
-# cosmos_container = cosmos_database.get_container_client(COSMOS_CONTAINER)
-
-
-# ----------------------------
-# Check if dataset view already exists
-# ----------------------------
-dataset_prefix = f"{args.output_name}/{view}/"
-
-existing_blobs = list(
-    container_client.list_blobs(name_starts_with=dataset_prefix)
-)
-
-if existing_blobs:
-    print(
-        f"⚠️ Dataset view '{dataset_name}/{view}' already exists in container "
-        f"'{args.container_name}'. No files were uploaded."
+    container_client = azure_client.get_blob_container(
+        connection_string=args.connection_string,
+        container_name=args.container_name,
     )
-    exit(0)
+    azure_client.ensure_blob_container_exists(container_client)
 
-# ----------------------------
-# Upload images
-# ----------------------------
-valid_extensions = (".glb", ".ply", ".stl")
-uploaded_count = 0
-
-for filename in os.listdir(input_dir):
-    if not filename.lower().endswith(valid_extensions):
-        continue
-
-    local_path = os.path.join(input_dir, filename)
-    
-    # Clarity check 
-    # clarity_threshold = 100.0
-    # img = cv2.imread(local_path)
-    # if img is None: 
-    #     sharpness_score = None
-    #     is_clear = False
-    # else: 
-    #     sharpness_score = laplacian_sharpness_score(img)
-    #     is_clear = sharpness_score >= clarity_threshold
-    
-    # Azure blob paths always use forward slashes
-    blob_name = f"{args.output_name}/{view}/{filename}".lower()
-
-    basename, ext = os.path.splitext(filename)
-    if ext[0] == '.':
-        ext = ext[1:]
-
-    with open(local_path, "rb") as f:
-        container_client.upload_blob(
-            name=blob_name,
-            data=f,
-            overwrite=True,
-            content_settings=ContentSettings(content_type="model/" + ext)
+    dataset_prefix = f"{args.output_name}/{view}/"
+    existing_blobs = list(container_client.list_blobs(name_starts_with=dataset_prefix))
+    if existing_blobs:
+        print(
+            f"⚠️ Dataset view '{dataset_name}/{view}' already exists in container "
+            f"'{args.container_name}'. No files were uploaded."
         )
+        return
 
-    # cosmos_view = "exo" if view == "orig" else view
-    frame_id = f"{args.container_name}_{args.output_name}_{view}_{filename}"
-    
-    # metadata_item = {
-    #     "id": frame_id,
-    #     "ContainerName": args.container_name,
-    #     "DatasetName": args.output_name,
-    #     "View": cosmos_view,
-    #     "FrameName": filename,
-    #     "BlobPath": blob_name,
-    #     "Date": args.date,
-    #     "MiscTags": misc_tags,
-    #     "SharpnessScore": sharpness_score,
-    #     "Clear": is_clear
-    # }
-    
-    # try:
-    #     cosmos_container.upsert_item(metadata_item)
-    # except Exception as e:
-    #     print(f"Failed to upload {filename} metadata to Cosmos: {e}")
+    valid_extensions = (".glb", ".ply", ".stl")
+    uploaded_count = 0
 
-    uploaded_count += 1
-    print(f"Uploaded ({uploaded_count}): {blob_name}")
+    for filename in os.listdir(input_dir):
+        if not filename.lower().endswith(valid_extensions):
+            continue
+
+        local_path = os.path.join(input_dir, filename)
+        blob_name = f"{args.output_name}/{view}/{filename}".lower()
+        _, ext = os.path.splitext(filename)
+        if ext and ext[0] == ".":
+            ext = ext[1:]
+
+        with open(local_path, "rb") as f:
+            container_client.upload_blob(
+                name=blob_name,
+                data=f,
+                overwrite=True,
+                content_settings=ContentSettings(content_type="model/" + ext),
+            )
+
+        uploaded_count += 1
+        print(f"Uploaded ({uploaded_count}): {blob_name}")
+
+    print(
+        f"✅ Upload complete — {uploaded_count} 3D files uploaded "
+        f"from '{dataset_name}/{view}' to '{args.container_name}'"
+    )
 
 
-print(
-    f"✅ Upload complete — {uploaded_count} images uploaded "
-    f"from '{dataset_name}/{view}' "
-    f"to '{args.container_name}' "
-)
-# print(f"{uploaded_count} documents created in Cosmos DB")
+if __name__ == "__main__":
+    main()

--- a/dashboard/src/pages/DataViewer.tsx
+++ b/dashboard/src/pages/DataViewer.tsx
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { useLocation, useNavigate, Link } from 'react-router-dom';
 import { Sidebar } from '../components/Sidebar';
 import { UploadModal } from '../components/UploadModal';
-import { Loader2, RefreshCw, Folder, Database, Terminal, AlertCircle } from 'lucide-react';
+import { Loader2, RefreshCw, Folder, Database, Terminal, AlertCircle, MoreVertical, Trash2 } from 'lucide-react';
 import { ImageGrid } from '../components/ImageGrid';
 import { ImageModal } from '../components/ImageModal';
 import Navigation from '../components/Navigation';
@@ -24,6 +24,9 @@ export default function DataViewer() {
     const [selectedImage, setSelectedImage] = useState(null);
     const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
     const [filterText, setFilterText] = useState('');
+    const [folderDropdownOpen, setFolderDropdownOpen] = useState<string | null>(null);
+    const [deleteModalFolder, setDeleteModalFolder] = useState<{ name: string; full_path: string } | null>(null);
+    const [deleteInProgress, setDeleteInProgress] = useState(false);
 
     // Tag State
     const [availableTags, setAvailableTags] = useState<string[]>([]);
@@ -109,14 +112,27 @@ export default function DataViewer() {
     };
 
     const handleFolderClick = (folderName: string) => {
-        // Navigate deeper
-        // current: /viewer/automotive
-        // click: bmw
-        // next: /viewer/automotive/bmw
         const nextPath = location.pathname.endsWith('/')
             ? `${location.pathname}${folderName}`
             : `${location.pathname}/${folderName}`;
         navigate(nextPath);
+    };
+
+    const handleDeleteFolder = async () => {
+        if (!deleteModalFolder) return;
+        setDeleteInProgress(true);
+        try {
+            await axios.post("/api/delete_dataset", { path: deleteModalFolder.full_path });
+            setDeleteModalFolder(null);
+            setFolderDropdownOpen(null);
+            const path = currentBackendPath ? currentBackendPath + "/" : "";
+            const res = await axios.get("/api/datasets", { params: { path } });
+            setFolders(res.data);
+        } catch (err: any) {
+            alert(err?.response?.data?.error || err?.message || "Delete failed");
+        } finally {
+            setDeleteInProgress(false);
+        }
     };
 
     // Filter Logic (for Images)
@@ -280,10 +296,40 @@ export default function DataViewer() {
                                         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8 max-w-5xl mx-auto">
                                             {filteredContent.map((folder: any) => (
                                                 <div
-                                                    key={folder.name}
+                                                    key={folder.full_path}
                                                     onClick={() => handleFolderClick(folder.name)}
-                                                    className="group cursor-pointer relative p-8 bg-card/20 border border-border hover:border-primary/50 hover:bg-card/40 transition-all duration-300 overflow-hidden"
+                                                    className="group cursor-pointer relative p-8 bg-card/20 border border-border hover:border-primary/50 hover:bg-card/40 transition-all duration-300 overflow-visible"
                                                 >
+                                                    {/* Folder actions dropdown */}
+                                                    <div className="absolute top-3 right-3 z-20" onClick={(e) => e.stopPropagation()}>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => setFolderDropdownOpen(folderDropdownOpen === folder.full_path ? null : folder.full_path)}
+                                                            className="p-1.5 rounded-sm text-muted-foreground hover:text-foreground hover:bg-primary/10 transition-colors"
+                                                            aria-label="Folder options"
+                                                        >
+                                                            <MoreVertical className="w-5 h-5" />
+                                                        </button>
+                                                        {folderDropdownOpen === folder.full_path && (
+                                                            <>
+                                                                <div className="fixed inset-0 z-10" onClick={() => setFolderDropdownOpen(null)} aria-hidden />
+                                                                <div className="absolute right-0 mt-1 py-1 w-40 bg-card border border-border rounded-sm shadow-lg z-20">
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={() => {
+                                                                            setDeleteModalFolder({ name: folder.name, full_path: folder.full_path });
+                                                                            setFolderDropdownOpen(null);
+                                                                        }}
+                                                                        className="w-full px-3 py-2 text-left text-sm font-sans-tech text-destructive hover:bg-destructive/10 flex items-center gap-2"
+                                                                    >
+                                                                        <Trash2 className="w-4 h-4" />
+                                                                        Delete
+                                                                    </button>
+                                                                </div>
+                                                            </>
+                                                        )}
+                                                    </div>
+
                                                     {/* Decorative corners */}
                                                     <div className="absolute top-0 left-0 w-3 h-3 border-t border-l border-border group-hover:border-primary transition-colors"></div>
                                                     <div className="absolute top-0 right-0 w-3 h-3 border-t border-r border-border group-hover:border-primary transition-colors"></div>
@@ -350,6 +396,37 @@ export default function DataViewer() {
                     onClose={() => setIsUploadModalOpen(false)}
                     onSuccess={() => {/* refresh */ }}
                 />
+
+                {/* Delete folder confirmation modal */}
+                {deleteModalFolder && (
+                    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm p-4">
+                        <div className="bg-card border border-border rounded-lg shadow-xl max-w-md w-full p-6" onClick={(e) => e.stopPropagation()}>
+                            <h3 className="text-lg font-sans-tech font-bold text-foreground mb-2">Delete path and subdirectories?</h3>
+                            <p className="text-sm text-muted-foreground font-sans-tech mb-1">
+                                You are about to delete <span className="text-foreground font-medium">{deleteModalFolder.full_path}</span> and all of its contents.
+                            </p>
+                            <p className="text-xs text-destructive/90 font-sans-tech mb-6">This action cannot be undone.</p>
+                            <div className="flex justify-end gap-3">
+                                <button
+                                    type="button"
+                                    onClick={() => setDeleteModalFolder(null)}
+                                    className="px-4 py-2 text-sm font-sans-tech font-medium text-muted-foreground hover:text-foreground border border-border rounded-sm transition-colors"
+                                >
+                                    Cancel
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={handleDeleteFolder}
+                                    disabled={deleteInProgress}
+                                    className="px-4 py-2 text-sm font-sans-tech font-medium text-primary-foreground bg-destructive hover:bg-destructive/90 rounded-sm transition-colors disabled:opacity-50 flex items-center gap-2"
+                                >
+                                    {deleteInProgress && <Loader2 className="w-4 h-4 animate-spin" />}
+                                    Delete
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     )


### PR DESCRIPTION
Adds backend/utils/delete_from_azure.py to support safe deletion of dataset data from Azure Blob Storage and Cosmos DB.

The script:
- Queries Cosmos DB for matching documents
- Collects blobPath values
- Deletes corresponding blobs from Azure Blob Storage
- Deletes the matching Cosmos DB documents
- Supports filters: --dataset, --tag, --view
- Supports --dry_run mode for safe testing
- Requires at least one filter to prevent accidental full deletion

Testing instructions:
1. Ensure a local .env file exists with required credentials: BLOB_CONNECTION_STRING=<azure blob connection string> COSMOS_DB_KEY=<cosmos db key> COSMOS_ENDPOINT=<cosmos endpoint if different from default> AZURE_BLOB_CONTAINER=<container name if different from default>

2. Install dependencies if needed: pip install azure-storage-blob azure-cosmos python-dotenv

3. Run a dry run first to verify matches: python backend/utils/delete_from_azure.py --dataset <dataset_name> --dry_run

4. After verifying output, run without --dry_run to perform deletion.