### PR TITLE
Add VLM tags UI and create_vlm_tags flow

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -167,6 +167,22 @@ def register_routes(app: Flask) -> None:
             logger.error(f"Error generating corner case: {e}", exc_info=True)
             return {"error": f"An error occurred: {str(e)}"}, 500
 
+    @app.route("/api/create_vlm_tags", methods=["POST"])
+    def create_vlm_tags():
+        """Create VLM tags for an ego or corner case image via Lambda VM and append to Cosmos DB."""
+        try:
+            data = request.get_json()
+            if not data:
+                return jsonify({"error": "Invalid JSON body"}), 400
+            result = processing_service.create_vlm_tags(data)
+            if result[1] != 200:
+                return jsonify({"error": result[0]}), result[1]
+            logger.info("VLM tags created successfully")
+            return jsonify(result[0]), result[1]
+        except Exception as e:
+            logger.error(f"Error creating VLM tags: {e}", exc_info=True)
+            return jsonify({"error": str(e)}), 500
+
     @app.route("/api/delete_dataset", methods=["POST"])
     def delete_dataset():
         """Delete a dataset path and its subdirectories via delete_from_azure.py script."""

--- a/backend/datara/services/call_lambda_vm.py
+++ b/backend/datara/services/call_lambda_vm.py
@@ -6,9 +6,9 @@ import paramiko
 
 import saas_config
 
-# Save ego/corner outputs under backend/dataset_list for upload_frames_to_azure
+# Save ego/corner outputs under backend/utils/dataset_list for upload_frames_to_azure
 BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-DATASET_LIST_DIR = os.path.join(BACKEND_DIR, "dataset_list")
+DATASET_LIST_DIR = os.path.join(BACKEND_DIR, "utils", "dataset_list")
 
 
 @contextmanager
@@ -53,7 +53,7 @@ def _run_command(client, command):
 def generate_ego_image(prompt, imageURL, container_name, output_name):
     """
     Run ego image generation on the Lambda VM and save the result under
-    backend/dataset_list/{output_name}/egos/. Returns (local_path, status_code).
+    backend/utils/dataset_list/{output_name}/egos/. Returns (local_path, status_code).
     """
     command = (
         "python ~/Software-as-a-Service/image_prompt_tool.py"
@@ -102,11 +102,58 @@ def _shell_escape(s):
     return s.replace("\\", "\\\\").replace('"', '\\"').replace("$", "\\$").replace("`", "\\`")
 
 
+def run_vlm_tags(prompt: str, image_url: str):
+    """
+    Run the VLM image tagging script on the Lambda VM. Runs qwen_vlm_image.py with
+    the given prompt and egoURL. Fetches the output JSON file locally, then removes
+    it from the VM. Returns (local_json_path, status_code). On failure returns (None, status_code).
+    """
+    if not prompt or not image_url:
+        return None, 400
+
+    safe_prompt = _shell_escape(prompt)
+    safe_url = _shell_escape(image_url)
+    command = (
+        'python "$HOME/Software-as-a-Service/Post Annotation/qwen_vlm_image.py" '
+        f'--prompt "{safe_prompt}" --egoURL "{safe_url}"'
+    )
+    logger.info(f"call_lambda_vm.run_vlm_tags() command: {command}")
+
+    try:
+        with _ssh_session() as ssh_client:
+            stdout, stderr = _run_command(ssh_client, command)
+            remote_json_path = (stdout.strip().split("\n")[-1].strip() if stdout else "") or ""
+
+            if not remote_json_path or not remote_json_path.endswith(".json"):
+                logger.error(f"VLM script failed or returned invalid path: {stderr or stdout}")
+                return None, 500
+
+            # Fetch JSON file locally to a temp path under backend
+            os.makedirs(DATASET_LIST_DIR, exist_ok=True)
+            local_json_path = os.path.join(DATASET_LIST_DIR, os.path.basename(remote_json_path))
+
+            sftp = ssh_client.open_sftp()
+            try:
+                sftp.get(remote_json_path, local_json_path)
+            finally:
+                sftp.close()
+
+            # Remove the file from the Lambda VM
+            _run_command(ssh_client, f"rm -f '{remote_json_path}'")
+
+            if os.path.exists(local_json_path):
+                return local_json_path, 200
+            return None, 500
+    except Exception as e:
+        logger.error(f"run_vlm_tags error: {e}")
+        return None, 500
+
+
 def invoke_corner_case(text, image_url, container_name, output_name):
     """
     Invoke corner-case handling on the Lambda VM. Runs corner_case_tool.py with
     the given text, image URL, and container name. On success, SFTPs the result
-    down and saves it under backend/dataset_list/{output_name}/corner_images_controlnet/.
+    down and saves it under backend/utils/dataset_list/{output_name}/corner_images_controlnet/.
     Returns (local_path, status_code).
     """
     if not text or not image_url or not container_name:

--- a/backend/datara/services/processing_service.py
+++ b/backend/datara/services/processing_service.py
@@ -16,12 +16,8 @@ from datara.logging import logger
 # Get the backend directory path and utils path
 BACKEND_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 UTILS_DIR = os.path.join(BACKEND_DIR, "utils")
-<<<<<<< HEAD
-DATASET_LIST_DIR = os.path.join(BACKEND_DIR, "dataset_list")
-=======
 # All upload scripts receive input_dir under this base (backend/utils/dataset_list)
 DATASET_LIST_DIR = os.path.join(UTILS_DIR, "dataset_list")
->>>>>>> main
 
 
 class ProcessingService:
@@ -421,3 +417,55 @@ class ProcessingService:
         except Exception as e:
             print(f"Corner case error: {e}")
             return {"error": f"Corner case generation failed: {str(e)}"}, 500
+
+    def create_vlm_tags(self, data: Dict[str, Any]) -> tuple[str, int]:
+        """
+        Create VLM tags for an ego or corner case image: call Lambda VM to produce
+        a JSON with VLM_tags, then append those tags to the image's Cosmos DB document.
+        """
+        logger.info(f"create_vlm_tags() called with data: {data}")
+        try:
+            prompt = data.get("prompt")
+            image_url = data.get("imageURL")
+
+            if not prompt or not str(prompt).strip():
+                return {"error": "Missing or empty 'prompt' in request body"}, 400
+            if not image_url or not str(image_url).strip():
+                return {"error": "Missing or empty 'imageURL' in request body"}, 400
+
+            prompt = str(prompt).strip()
+            image_url = str(image_url).strip()
+
+            try:
+                from datara.services import call_lambda_vm
+                local_json_path, status_code = call_lambda_vm.run_vlm_tags(prompt, image_url)
+            except (ImportError, AttributeError):
+                logger.warning("call_lambda_vm module not found")
+                return {"error": "VLM tags module not available"}, 500
+            except Exception as e:
+                logger.error(f"Error in run_vlm_tags: {e}")
+                return {"error": f"VLM tags generation failed: {str(e)}"}, 500
+
+            if status_code != 200 or not local_json_path or not os.path.exists(local_json_path):
+                return {"error": "VLM tags invocation failed or no JSON produced"}, status_code or 500
+
+            try:
+                append_script = os.path.join(UTILS_DIR, "append_tags_to_image.py")
+                subprocess.check_call(
+                    [sys.executable, append_script, "--egoURL", image_url, "--json_path", local_json_path],
+                    cwd=BACKEND_DIR,
+                )
+            finally:
+                if os.path.exists(local_json_path):
+                    try:
+                        os.remove(local_json_path)
+                    except OSError:
+                        pass
+
+            return {"message": "VLM tags created and appended successfully"}, 200
+        except subprocess.CalledProcessError as e:
+            logger.error(f"append_tags_to_image failed: {e}")
+            return {"error": f"Appending tags failed: {str(e)}"}, 500
+        except Exception as e:
+            logger.error(f"create_vlm_tags error: {e}", exc_info=True)
+            return {"error": str(e)}, 500

--- a/backend/utils/append_tags_to_image.py
+++ b/backend/utils/append_tags_to_image.py
@@ -1,0 +1,91 @@
+"""
+Store VLM_tags from a JSON file on the Cosmos DB document for an image (by egoURL).
+
+Usage:
+  python append_tags_to_image.py --egoURL <image_blob_url> --json_path <path_to_json>
+
+The JSON file must have a key "VLM_tags" whose value is a list of strings.
+Finds the Cosmos document for the image by matching container and blob path from the URL,
+then sets the document's "VLM_tags" key to that list, keeping miscTags separate.
+"""
+
+import argparse
+import json
+import os
+import sys
+from urllib.parse import urlparse
+
+# Allow running as python backend/utils/append_tags_to_image.py
+_BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _BACKEND not in sys.path:
+    sys.path.insert(0, _BACKEND)
+from utils import azure_client
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Set VLM_tags from JSON on Cosmos DB document for image URL")
+    p.add_argument("--egoURL", required=True, help="Blob URL of the image (used to find Cosmos document)")
+    p.add_argument("--json_path", required=True, help="Path to JSON file with VLM_tags list")
+    return p.parse_args()
+
+
+def blob_path_from_url(url: str):
+    """Extract container name and blob path from a blob storage URL."""
+    parsed = urlparse(url)
+    path = (parsed.path or "").strip("/")
+    parts = path.split("/")
+    if len(parts) < 2:
+        raise ValueError(f"Cannot parse blob path from URL: {url}")
+    container_name = parts[0]
+    blob_path = "/".join(parts[1:])
+    return container_name, blob_path
+
+
+def main():
+    args = parse_args()
+    if not os.path.isfile(args.json_path):
+        print(f"JSON file not found: {args.json_path}", file=sys.stderr)
+        sys.exit(1)
+
+    with open(args.json_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    vlm_tags = data.get("VLM_tags")
+    if not isinstance(vlm_tags, list):
+        print("JSON must contain 'VLM_tags' as a list of strings", file=sys.stderr)
+        sys.exit(1)
+    vlm_tags = [str(t) for t in vlm_tags]
+
+    try:
+        container_name, blob_path = blob_path_from_url(args.egoURL)
+    except ValueError as e:
+        print(e, file=sys.stderr)
+        sys.exit(1)
+
+    cosmos_container = azure_client.get_cosmos_container()
+    query = "SELECT * FROM c WHERE c.containerName = @cn AND c.blobPath = @bp"
+    items = list(
+        cosmos_container.query_items(
+            query=query,
+            parameters=[
+                {"name": "@cn", "value": container_name},
+                {"name": "@bp", "value": blob_path},
+            ],
+            enable_cross_partition_query=True,
+        )
+    )
+
+    if not items:
+        print(f"No Cosmos document found for container={container_name}, blobPath={blob_path}", file=sys.stderr)
+        sys.exit(1)
+    if len(items) > 1:
+        print(f"Multiple documents matched; using first. container={container_name}, blobPath={blob_path}", file=sys.stderr)
+
+    doc = items[0]
+    doc["VLM_tags"] = vlm_tags
+
+    cosmos_container.upsert_item(doc)
+    print(f"Set VLM_tags ({len(vlm_tags)} items) on document {doc['id']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/dashboard/src/components/ImageModal.tsx
+++ b/dashboard/src/components/ImageModal.tsx
@@ -39,6 +39,8 @@ export function ImageModal({ image, onClose, onNext, onPrev, onEgoGenSuccess, on
     const [isGeneratingEgo, setIsGeneratingEgo] = useState(false);
     const [cornerCasePrompt, setCornerCasePrompt] = useState("");
     const [isAddingCornerCase, setIsAddingCornerCase] = useState(false);
+    const [vlmTagsPrompt, setVlmTagsPrompt] = useState("");
+    const [isCreatingVlmTags, setIsCreatingVlmTags] = useState(false);
 
     const addCornerCase = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -76,6 +78,33 @@ export function ImageModal({ image, onClose, onNext, onPrev, onEgoGenSuccess, on
             alert(`Error: ${error.message}`);
         } finally {
             setIsAddingCornerCase(false);
+        }
+    };
+
+    const createVlmTags = async (e: React.FormEvent) => {
+        e.preventDefault();
+        const prompt = vlmTagsPrompt.trim();
+        if (!prompt) return;
+
+        setIsCreatingVlmTags(true);
+        try {
+            const response = await fetch("/api/create_vlm_tags", {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ prompt, imageURL: image.url }),
+            });
+            const data = await response.json();
+            if (response.ok) {
+                alert(data.message || "VLM tags created successfully.");
+                setVlmTagsPrompt("");
+                onClose();
+            } else {
+                throw new Error(data.error || "Create VLM tags failed");
+            }
+        } catch (error: any) {
+            alert(`Error: ${error.message}`);
+        } finally {
+            setIsCreatingVlmTags(false);
         }
     };
 
@@ -247,6 +276,30 @@ export function ImageModal({ image, onClose, onNext, onPrev, onEgoGenSuccess, on
                             </div>
                         </div>
                     </div>
+
+                    {/* VLM tags — for ego or corner case images */}
+                    {(image.metadata?.view === "egos" || image.metadata?.view === "corner_images_controlnet") ? (
+                        <div>
+                            <label className="text-xs font-bold text-muted-foreground uppercase tracking-widest block mb-2 font-sans-tech">Create VLM tags</label>
+                            <form onSubmit={createVlmTags} className="space-y-3">
+                                <input
+                                    type="text"
+                                    value={vlmTagsPrompt}
+                                    onChange={(e) => setVlmTagsPrompt(e.target.value)}
+                                    placeholder="Enter prompt for VLM tagging"
+                                    className="w-full px-3 py-2 text-sm bg-input rounded-sm border border-border focus:border-primary/50 focus:outline-none font-sans-tech placeholder:text-muted-foreground"
+                                />
+                                <button
+                                    type="submit"
+                                    disabled={!vlmTagsPrompt.trim() || isCreatingVlmTags}
+                                    className="px-6 py-2 bg-primary hover:bg-primary/90 text-primary-foreground text-xs font-bold font-sans-tech rounded-sm flex items-center gap-2 transition-all disabled:opacity-50 disabled:cursor-not-allowed uppercase shadow-lg shadow-primary/20"
+                                >
+                                    {isCreatingVlmTags && <Loader2 className="w-3 h-3 animate-spin" />}
+                                    {isCreatingVlmTags ? "Creating..." : "Create VLM tags"}
+                                </button>
+                            </form>
+                        </div>
+                    ) : null}
 
                     {/* Corner case — only for ego images */}
                     {image.metadata?.view === "egos" ? (


### PR DESCRIPTION
- ImageModal: VLM tags prompt + button for ego/corner case images
- POST /api/create_vlm_tags in app.py
- processing_service.create_vlm_tags: call Lambda VM, then append_tags_to_image
- call_lambda_vm.run_vlm_tags: SSH, run qwen_vlm_image.py, fetch JSON, remove on VM
- append_tags_to_image.py: append VLM_tags from JSON to Cosmos doc by egoURL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new end-to-end tagging pipeline that executes a remote SSH command on the Lambda VM and upserts `VLM_tags` into Cosmos DB documents, which could impact data integrity and operational reliability if the script output/URL parsing is wrong.
> 
> **Overview**
> Adds a new **VLM image-tagging workflow**: the dashboard `ImageModal` now lets users submit a prompt for *ego* and *corner case* images, calling a new `POST /api/create_vlm_tags` endpoint.
> 
> On the backend, `ProcessingService.create_vlm_tags` SSHes to the Lambda VM to run `qwen_vlm_image.py`, downloads the resulting JSON, and then runs `utils/append_tags_to_image.py` to set `VLM_tags` on the matching Cosmos DB document (by parsing `imageURL` into `containerName` + `blobPath`). Also standardizes Lambda VM artifact storage under `backend/utils/dataset_list`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6090bd5b68b6b82c0105ae305ce8f04ce0e7de2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->