### PR TITLE
Add unit and integration tests for user authentication.

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = .
+testpaths = tests

--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=8.0.0
+pytest-cov>=5.0.0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,90 @@
+"""Shared pytest fixtures for Datara backend tests."""
+
+from __future__ import annotations
+
+import os
+
+# Configure auth database before any app/datara imports that touch SQLStore.
+os.environ.setdefault("AUTH_DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("FLASK_SECRET_KEY", "test-secret-key-for-pytest")
+os.environ.setdefault("AUTH_REGISTRATION_ENABLED", "true")
+os.environ.setdefault("AUTH_ALLOW_PENDING_LOGIN_SESSION", "true")
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from datara.services.auth_service import AuthService
+from datara.services.sql_store import SQLStore
+
+TEST_PASSWORD = "password1234"
+
+
+@pytest.fixture
+def sql_store() -> SQLStore:
+    return SQLStore(database_url="sqlite:///:memory:")
+
+
+@pytest.fixture
+def auth_service(sql_store: SQLStore) -> AuthService:
+    return AuthService(sql_store)
+
+
+@pytest.fixture
+def app(sql_store: SQLStore, auth_service: AuthService, monkeypatch: pytest.MonkeyPatch):
+    import app as app_module
+
+    monkeypatch.setattr(app_module, "sql_store", sql_store)
+    monkeypatch.setattr(app_module, "auth_service", auth_service)
+
+    flask_app = app_module.create_app()
+    flask_app.config["TESTING"] = True
+    flask_app.config["SECRET_KEY"] = "test-secret-key-for-pytest"
+    return flask_app
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client(use_cookies=True)
+
+
+def make_user(
+    sql_store: SQLStore,
+    *,
+    email: str = "user@example.com",
+    display_name: str = "Test User",
+    password: str = TEST_PASSWORD,
+    approval_status: str = "approved",
+    role: str = "customer",
+) -> dict:
+    return sql_store.create_user(
+        email=email,
+        display_name=display_name,
+        password_hash=generate_password_hash(password),
+        approval_status=approval_status,
+        role=role,
+    )
+
+
+@pytest.fixture
+def approved_user(sql_store: SQLStore) -> dict:
+    return make_user(sql_store)
+
+
+@pytest.fixture
+def pending_user(sql_store: SQLStore) -> dict:
+    return make_user(
+        sql_store,
+        email="pending@example.com",
+        display_name="Pending User",
+        approval_status="pending",
+    )
+
+
+@pytest.fixture
+def rejected_user(sql_store: SQLStore) -> dict:
+    return make_user(
+        sql_store,
+        email="rejected@example.com",
+        display_name="Rejected User",
+        approval_status="rejected",
+    )

--- a/backend/tests/integration/test_auth_routes.py
+++ b/backend/tests/integration/test_auth_routes.py
@@ -1,0 +1,169 @@
+"""Integration tests for Flask auth routes (register, login, me, logout)."""
+
+from __future__ import annotations
+
+from tests.conftest import TEST_PASSWORD, make_user
+
+
+def test_register_creates_account_and_session(client) -> None:
+    response = client.post(
+        "/api/auth/register",
+        json={
+            "email": "newuser@example.com",
+            "displayName": "New User",
+            "password": TEST_PASSWORD,
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.get_json()
+    assert body["isAuthenticated"] is True
+    assert body["user"]["email"] == "newuser@example.com"
+    assert body["user"]["displayName"] == "New User"
+
+
+def test_register_rejects_duplicate_email(client, approved_user: dict) -> None:
+    response = client.post(
+        "/api/auth/register",
+        json={
+            "email": approved_user["email"],
+            "displayName": "Duplicate",
+            "password": TEST_PASSWORD,
+        },
+    )
+
+    assert response.status_code == 409
+
+
+def test_login_with_valid_credentials(client, approved_user: dict) -> None:
+    response = client.post(
+        "/api/auth/login",
+        json={"email": approved_user["email"], "password": TEST_PASSWORD},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["isAuthenticated"] is True
+    assert body["isApproved"] is True
+    assert body["user"]["email"] == approved_user["email"]
+
+
+def test_login_rejects_invalid_password(client, approved_user: dict) -> None:
+    response = client.post(
+        "/api/auth/login",
+        json={"email": approved_user["email"], "password": "wrong-password"},
+    )
+
+    assert response.status_code == 401
+
+
+def test_auth_me_unauthenticated(client) -> None:
+    response = client.get("/api/auth/me")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["isAuthenticated"] is False
+    assert body["user"] is None
+
+
+def test_auth_me_returns_logged_in_user(client, approved_user: dict) -> None:
+    login_response = client.post(
+        "/api/auth/login",
+        json={"email": approved_user["email"], "password": TEST_PASSWORD},
+    )
+    assert login_response.status_code == 200
+
+    response = client.get("/api/auth/me")
+    body = response.get_json()
+
+    assert body["isAuthenticated"] is True
+    assert body["user"]["id"] == approved_user["id"]
+    assert body["user"]["email"] == approved_user["email"]
+
+
+def test_logout_clears_session(client, approved_user: dict) -> None:
+    client.post(
+        "/api/auth/login",
+        json={"email": approved_user["email"], "password": TEST_PASSWORD},
+    )
+
+    logout_response = client.post("/api/auth/logout")
+    assert logout_response.status_code == 200
+
+    me_response = client.get("/api/auth/me")
+    assert me_response.get_json()["isAuthenticated"] is False
+
+
+def test_register_then_login_flow(client) -> None:
+    email = "flow@example.com"
+
+    register_response = client.post(
+        "/api/auth/register",
+        json={
+            "email": email,
+            "displayName": "Flow User",
+            "password": TEST_PASSWORD,
+        },
+    )
+    assert register_response.status_code == 201
+
+    client.post("/api/auth/logout")
+
+    login_response = client.post(
+        "/api/auth/login",
+        json={"email": email, "password": TEST_PASSWORD},
+    )
+    assert login_response.status_code == 200
+    assert login_response.get_json()["isAuthenticated"] is True
+
+
+def test_login_rejects_rejected_user(client, rejected_user: dict) -> None:
+    response = client.post(
+        "/api/auth/login",
+        json={"email": rejected_user["email"], "password": TEST_PASSWORD},
+    )
+
+    assert response.status_code == 403
+
+
+def test_protected_admin_route_requires_authentication(client) -> None:
+    response = client.get("/api/admin/users")
+
+    assert response.status_code == 401
+    body = response.get_json()
+    assert body["error"] == "authentication_required"
+
+
+def test_protected_admin_route_requires_approved_account_manager(
+    client, sql_store, approved_user: dict
+) -> None:
+    client.post(
+        "/api/auth/login",
+        json={"email": approved_user["email"], "password": TEST_PASSWORD},
+    )
+
+    response = client.get("/api/admin/users")
+    assert response.status_code == 403
+    assert response.get_json()["error"] == "account_manager_required"
+
+
+def test_admin_can_list_users(client, sql_store) -> None:
+    admin = make_user(
+        sql_store,
+        email="admin@example.com",
+        display_name="Admin",
+        approval_status="approved",
+        role="admin",
+    )
+    make_user(sql_store, email="customer@example.com", display_name="Customer")
+
+    client.post(
+        "/api/auth/login",
+        json={"email": admin["email"], "password": TEST_PASSWORD},
+    )
+
+    response = client.get("/api/admin/users")
+    assert response.status_code == 200
+    emails = {user["email"] for user in response.get_json()["users"]}
+    assert "admin@example.com" in emails
+    assert "customer@example.com" in emails

--- a/backend/tests/integration/test_sql_store_users.py
+++ b/backend/tests/integration/test_sql_store_users.py
@@ -1,0 +1,68 @@
+"""Integration tests for SQLStore user credential storage and lookup."""
+
+from __future__ import annotations
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+from datara.services.sql_store import SQLStore
+from tests.conftest import TEST_PASSWORD, make_user
+
+
+def test_create_user_stores_normalized_email_and_password_hash(sql_store: SQLStore) -> None:
+    password_hash = generate_password_hash(TEST_PASSWORD)
+    user = sql_store.create_user(
+        email="User@Example.COM",
+        display_name="Test User",
+        password_hash=password_hash,
+        approval_status="approved",
+        role="customer",
+    )
+
+    assert user["email"] == "user@example.com"
+    assert user["display_name"] == "Test User"
+    assert user["approval_status"] == "approved"
+    assert user["role"] == "customer"
+    assert user["storage_slug"]
+    assert user["private_container_name"]
+    assert check_password_hash(user["password_hash"], TEST_PASSWORD)
+
+
+def test_get_user_by_email_finds_existing_user(sql_store: SQLStore) -> None:
+    created = make_user(sql_store, email="lookup@example.com")
+
+    found = sql_store.get_user_by_email("lookup@example.com")
+    assert found is not None
+    assert found["id"] == created["id"]
+    assert found["email"] == "lookup@example.com"
+
+
+def test_get_user_by_email_is_case_insensitive(sql_store: SQLStore) -> None:
+    make_user(sql_store, email="case@example.com")
+
+    found = sql_store.get_user_by_email("CASE@EXAMPLE.COM")
+    assert found is not None
+    assert found["email"] == "case@example.com"
+
+
+def test_get_user_by_email_returns_none_for_missing_user(sql_store: SQLStore) -> None:
+    assert sql_store.get_user_by_email("missing@example.com") is None
+
+
+def test_touch_user_login_updates_timestamp(sql_store: SQLStore) -> None:
+    user = make_user(sql_store)
+    assert user.get("last_login_at") is None
+
+    sql_store.touch_user_login(user["id"])
+    refreshed = sql_store.get_user_by_id(user["id"])
+
+    assert refreshed is not None
+    assert refreshed["last_login_at"] is not None
+
+
+def test_password_verification_matches_stored_hash(sql_store: SQLStore) -> None:
+    user = make_user(sql_store, email="verify@example.com", password="my-secure-pass")
+
+    stored = sql_store.get_user_by_email("verify@example.com")
+    assert stored is not None
+    assert check_password_hash(stored["password_hash"], "my-secure-pass")
+    assert not check_password_hash(stored["password_hash"], "wrong-password")

--- a/backend/tests/unit/test_auth_service.py
+++ b/backend/tests/unit/test_auth_service.py
@@ -1,0 +1,313 @@
+"""Unit tests for AuthService login, register, and session behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from werkzeug.security import generate_password_hash
+
+from datara.services.auth_service import SESSION_USER_KEY, AuthService
+from tests.conftest import TEST_PASSWORD
+
+pytestmark = pytest.mark.usefixtures("monkeypatch")
+
+
+@pytest.fixture
+def flask_app() -> Flask:
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret"
+    return app
+
+
+@pytest.fixture
+def mock_sql_store() -> MagicMock:
+    store = MagicMock()
+    store.get_user_by_email.return_value = None
+    store.count_admin_users.return_value = 0
+    return store
+
+
+@pytest.fixture
+def auth_service(mock_sql_store: MagicMock) -> AuthService:
+    return AuthService(mock_sql_store)
+
+
+def _approved_user_dict(
+    *,
+    user_id: int = 1,
+    email: str = "user@example.com",
+    password: str = TEST_PASSWORD,
+    approval_status: str = "approved",
+    role: str = "customer",
+) -> dict:
+    return {
+        "id": user_id,
+        "email": email,
+        "display_name": "Test User",
+        "password_hash": generate_password_hash(password),
+        "approval_status": approval_status,
+        "role": role,
+        "storage_slug": "test-user",
+        "private_container_name": "private-test-user",
+    }
+
+
+class TestRegister:
+    def test_register_creates_user_and_session(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        created = _approved_user_dict(approval_status="pending")
+        mock_sql_store.create_user.return_value = created
+
+        with flask_app.test_request_context(
+            json={
+                "email": "user@example.com",
+                "displayName": "Test User",
+                "password": TEST_PASSWORD,
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 201
+        body = response.get_json()
+        assert body["isAuthenticated"] is True
+        assert body["isApproved"] is False
+        assert body["approvalStatus"] == "pending"
+        mock_sql_store.create_user.assert_called_once()
+        mock_sql_store.get_user_by_email.assert_called_once_with("user@example.com")
+
+    def test_register_rejects_duplicate_email(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        mock_sql_store.get_user_by_email.return_value = _approved_user_dict()
+
+        with flask_app.test_request_context(
+            json={
+                "email": "user@example.com",
+                "displayName": "Test User",
+                "password": TEST_PASSWORD,
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 409
+        assert response.get_json()["error"] == "An account with this email already exists"
+        mock_sql_store.create_user.assert_not_called()
+
+    def test_register_rejects_rejected_account_reregistration(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        mock_sql_store.get_user_by_email.return_value = _approved_user_dict(approval_status="rejected")
+
+        with flask_app.test_request_context(
+            json={
+                "email": "user@example.com",
+                "displayName": "Test User",
+                "password": TEST_PASSWORD,
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 403
+        assert "rejected" in response.get_json()["error"].lower()
+
+    def test_register_rejects_invalid_email(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        with flask_app.test_request_context(
+            json={
+                "email": "not-valid",
+                "displayName": "Test User",
+                "password": TEST_PASSWORD,
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 400
+        mock_sql_store.create_user.assert_not_called()
+
+    def test_register_rejects_short_password(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        with flask_app.test_request_context(
+            json={
+                "email": "user@example.com",
+                "displayName": "Test User",
+                "password": "short",
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 400
+        assert "at least" in response.get_json()["error"].lower()
+
+    def test_register_disabled_returns_503(
+        self,
+        flask_app: Flask,
+        auth_service: AuthService,
+        mock_sql_store: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("datara.services.auth_service.settings.auth_registration_enabled", False)
+
+        with flask_app.test_request_context(
+            json={
+                "email": "user@example.com",
+                "displayName": "Test User",
+                "password": TEST_PASSWORD,
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 503
+        mock_sql_store.create_user.assert_not_called()
+
+    def test_register_bootstraps_first_admin(
+        self,
+        flask_app: Flask,
+        auth_service: AuthService,
+        mock_sql_store: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "datara.services.auth_service.settings.auth_bootstrap_admin_emails",
+            ["admin@example.com"],
+        )
+        mock_sql_store.count_admin_users.return_value = 0
+        mock_sql_store.create_user.return_value = _approved_user_dict(
+            email="admin@example.com",
+            approval_status="approved",
+            role="admin",
+        )
+
+        with flask_app.test_request_context(
+            json={
+                "email": "admin@example.com",
+                "displayName": "Admin",
+                "password": TEST_PASSWORD,
+            }
+        ):
+            response, status = auth_service.register()
+
+        assert status == 201
+        assert response.get_json()["isApproved"] is True
+        create_kwargs = mock_sql_store.create_user.call_args.kwargs
+        assert create_kwargs["approval_status"] == "approved"
+        assert create_kwargs["role"] == "admin"
+
+
+class TestLogin:
+    def test_login_succeeds_for_valid_credentials(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        user = _approved_user_dict()
+        mock_sql_store.get_user_by_email.return_value = user
+        mock_sql_store.get_user_by_id.return_value = user
+
+        with flask_app.test_request_context(
+            json={"email": "user@example.com", "password": TEST_PASSWORD}
+        ):
+            response = auth_service.login()
+
+        body = response.get_json()
+        assert body["isAuthenticated"] is True
+        assert body["message"] == "Login successful"
+        mock_sql_store.touch_user_login.assert_called_once_with(user["id"])
+
+    def test_login_rejects_wrong_password(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        mock_sql_store.get_user_by_email.return_value = _approved_user_dict()
+
+        with flask_app.test_request_context(
+            json={"email": "user@example.com", "password": "wrong-password"}
+        ):
+            response, status = auth_service.login()
+
+        assert status == 401
+        assert response.get_json()["error"] == "Invalid email or password"
+
+    def test_login_rejects_unknown_email(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        mock_sql_store.get_user_by_email.return_value = None
+
+        with flask_app.test_request_context(
+            json={"email": "missing@example.com", "password": TEST_PASSWORD}
+        ):
+            response, status = auth_service.login()
+
+        assert status == 401
+
+    def test_login_rejects_rejected_account(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        mock_sql_store.get_user_by_email.return_value = _approved_user_dict(approval_status="rejected")
+
+        with flask_app.test_request_context(
+            json={"email": "user@example.com", "password": TEST_PASSWORD}
+        ):
+            response, status = auth_service.login()
+
+        assert status == 403
+        assert "rejected" in response.get_json()["error"].lower()
+
+    def test_login_rejects_pending_when_not_allowed(
+        self,
+        flask_app: Flask,
+        auth_service: AuthService,
+        mock_sql_store: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr("datara.services.auth_service.settings.auth_allow_pending_login_session", False)
+        mock_sql_store.get_user_by_email.return_value = _approved_user_dict(approval_status="pending")
+
+        with flask_app.test_request_context(
+            json={"email": "user@example.com", "password": TEST_PASSWORD}
+        ):
+            response, status = auth_service.login()
+
+        assert status == 403
+        assert "pending" in response.get_json()["error"].lower()
+
+    def test_login_requires_email_and_password(
+        self, flask_app: Flask, auth_service: AuthService, mock_sql_store: MagicMock
+    ) -> None:
+        with flask_app.test_request_context(json={"email": "user@example.com"}):
+            response, status = auth_service.login()
+
+        assert status == 400
+
+
+class TestSession:
+    def test_get_current_user_returns_none_without_session(
+        self, flask_app: Flask, auth_service: AuthService
+    ) -> None:
+        with flask_app.test_request_context():
+            assert auth_service.get_current_user() is None
+
+    def test_logout_clears_session(self, flask_app: Flask, auth_service: AuthService) -> None:
+        with flask_app.test_request_context():
+            from flask import session
+
+            session[SESSION_USER_KEY] = 42
+            response = auth_service.logout()
+
+        assert response.get_json()["ok"] is True
+        with flask_app.test_request_context():
+            from flask import session
+
+            assert SESSION_USER_KEY not in session
+
+    def test_serialize_user_unauthenticated(
+        self, flask_app: Flask, auth_service: AuthService
+    ) -> None:
+        with flask_app.test_request_context():
+            payload = auth_service.serialize_user(None)
+
+        assert payload["isAuthenticated"] is False
+        assert payload["user"] is None
+        assert "loginUrl" in payload
+        assert "registerUrl" in payload

--- a/backend/tests/unit/test_auth_validation.py
+++ b/backend/tests/unit/test_auth_validation.py
@@ -1,0 +1,49 @@
+"""Unit tests for AuthService email and password validation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from datara.services.auth_service import AuthService
+
+
+@pytest.mark.parametrize(
+    "email,expected",
+    [
+        ("user@example.com", True),
+        ("User@Example.COM", True),
+        ("name.with.dots@sub.example.com", True),
+        ("", False),
+        ("not-an-email", False),
+        ("missing-at-sign.com", False),
+        ("@no-local.com", False),
+        ("local@nodot", False),
+        ("local@.com", False),
+        ("local@com.", False),
+        (".local@example.com", False),
+        ("local.@example.com", False),
+        ("has space@example.com", False),
+        ("two@@example.com", False),
+    ],
+)
+def test_is_valid_email(email: str, expected: bool) -> None:
+    assert AuthService._is_valid_email(email) is expected
+
+
+def test_normalize_email_strips_and_lowercases() -> None:
+    assert AuthService._normalize_email("  User@Example.COM  ") == "user@example.com"
+    assert AuthService._normalize_email(None) == ""
+
+
+def test_sanitize_display_name_uses_fallback() -> None:
+    assert AuthService._sanitize_display_name("  Alice  ", "alice@example.com") == "Alice"
+    assert AuthService._sanitize_display_name("", "alice@example.com") == "alice@example.com"
+    assert AuthService._sanitize_display_name(None, "alice@example.com") == "alice@example.com"
+
+
+def test_password_error_rejects_short_passwords(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("datara.services.auth_service.settings.auth_min_password_length", 10)
+
+    auth_service = AuthService(sql_store=None)  # type: ignore[arg-type]
+    assert auth_service._password_error("short") == "Password must be at least 10 characters long"
+    assert auth_service._password_error("longenough") is None


### PR DESCRIPTION
Cover registration, login, session handling, and SQL-backed credential validation using in-memory SQLite so tests run without Azure SQL.